### PR TITLE
added token getter/setter, renamed auth_token to _auth_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Project will work on both python 2 and python 3
     buy_order = my_trader.place_buy_order(stock_instrument, 1)
     sell_order = my_trader.place_sell_order(stock_instrument, 1)
 
+    # save the token so you don't need user/password again
+    # should probably encrypt this if saving to a file
+    token = my_trader.token
+
+    # load from token rather than login
+    my_trader.token = token
+
 ### Data returned
 * Quote data
   + Ask Price


### PR DESCRIPTION
added token getter/setter, renamed auth_token to _auth_token, based on https://github.com/thisisnotyoho/Robinhood/commit/02bc5c36dcba9e05f74b87a49c42cdc17e2748df, though I used property instead and underscored _auth_token to prevent misuse and to allow the library user to save/load from token rather than storing credentials.

changed login function to use token setter
updated README.md to show token save/load
Also a couple trivial changes to spaces for pep8, nothing renamed or anything at all functional.