### PR TITLE
Instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Project will work on both python 2 and python 3
     buy_order = my_trader.place_buy_order(stock_instrument, 1)
     sell_order = my_trader.place_sell_order(stock_instrument, 1)
 
+    # save the token so you don't need user/password again
+    # should probably encrypt this if saving to a file
+    token = my_trader.token
+
+    # load from token rather than login
+    my_trader.token = token
+
 ### Data returned
 * Quote data
   + Ask Price


### PR DESCRIPTION
Fixes to the instruments method. I added code to strip the url so the library user, or other methods, doesn't have to do that. 

Also, if the lookup has a single result res['results'] won't exist to get the list from. Rather it will just be a single item without 'results'. Return [res] instead in that case.